### PR TITLE
using form attributes in blogs form

### DIFF
--- a/app/views/blogs/_form.html.erb
+++ b/app/views/blogs/_form.html.erb
@@ -4,22 +4,22 @@
       <h2><%= pluralize(blog.errors.count, "error") %> prohibited this blog from being saved:</h2>
 
       <ul>
-        <% blog.errors.each do |error| %>
-          <li><%= error.full_message %></li>
+        <% blog.errors&.full_messages&.each do |message| %>
+          <li><%= message %></li>
         <% end %>
       </ul>
     </div>
   <% end %>
 
   <div class="mb-3">
-    <label for="title" class="form-label">Title</label>
+    <%= form.label :title, "Title", class: 'form-label' %>
     <%= form.text_field :title, class: 'form-control' %>
     
   </div>
   <div class="mb-3">
-    <label for="body" class="form-label">Body</label>
+    <%= form.label :body, "Body", class: 'form-label' %>
     <%= form.text_area :body, class: 'form-control' %>
   </div>
 
-  <%= submit_tag "Submit", class: 'btn btn-primary' %>
+  <%= form.submit "Submit", class: 'btn btn-primary' %>
 <% end %>


### PR DESCRIPTION
This update assumes the use of a shared _form partial for both the "New Employee" and "Edit Employee" views to eliminate duplicate code. Since the Heroku API is currently not functioning, I was unable to test the changes. Therefore, the code for the _form partial for employee has not been pushed.

Additionally, form attributes are better suited for handling form interactions when using form_tag, ensuring improved compatibility and cleaner implementation.